### PR TITLE
Prevent crash where createdAt is not returned

### DIFF
--- a/custom_components/amberelectric/ambermodel.py
+++ b/custom_components/amberelectric/ambermodel.py
@@ -312,7 +312,10 @@ class VariablePricesAndRenewable:
     def from_dict(obj: Any) -> "VariablePricesAndRenewable":
         assert isinstance(obj, dict)
         period_type = PeriodType(obj.get("periodType"))
-        created_at = from_datetime(obj.get("createdAt"))
+        if obj.get("createdAt") == None:
+            created_at = ""
+        else:
+            created_at = from_datetime(obj.get("createdAt"))
         wholesale_kwh_price = from_str(obj.get("wholesaleKWHPrice"))
         usage = from_union([from_str, from_none], obj.get("usage"))
         region = from_str(obj.get("region"))


### PR DESCRIPTION
I will admit this isn't extensively tested because I don't know the overall solution too well, but I can confirm this fixes the issue as reported here: https://community.home-assistant.io/t/amber-electric-australia-custom-component/201231/18