### PR TITLE
Add configuration option to pull a different network name from the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,24 @@
 # Home Assistant Plugin for Amber Electric Real-Time Pricing
 
-A custom component for Home Assistant (www.home-assistant.io) to pull the latest energy prices from the Amber Electric (https://www.amberelectric.com.au/) REST API based on Post Code. 
+A custom component for Home Assistant (www.home-assistant.io) to pull the latest energy prices from the Amber Electric (https://www.amberelectric.com.au/) REST API based on Post Code.
 
 # How to install
 
 Copy custom_components/amberelectric to your hass data directory (where your configuration.yaml lives). It should go into the same directory structure (YOUR_CONFIG_DIRECTORY/custom_components/amberelectric)
 
-Add a sensor into your configuration.yaml file that defines the Post Code you want to lookup. 
+Add a sensor into your configuration.yaml file that defines the Post Code you want to lookup.
 
 ```yaml
 sensor:
   - platform: amberelectric
-    postcode: '2000'
+    postcode: "2000"
 ```
-Once deployed, you should see 2 sensors added to your Home Assistant entities list, one reflects the current solar feed-in tarrif, and the second is the real-time grid price charged by Amber (including their network fees). 
+
+Once deployed, you should see 2 sensors added to your Home Assistant entities list, one reflects the current solar feed-in tarrif, and the second is the real-time grid price charged by Amber (including their network fees).
 
 #Analysing Price Predictions
 
-The 12 hour price predictions from Amber for both solar FiT and grid usage are available as an attribute of the sensor. To use this data-set in automation or scenes, it is best to return the array using a template to achieve what you need. 
+The 12 hour price predictions from Amber for both solar FiT and grid usage are available as an attribute of the sensor. To use this data-set in automation or scenes, it is best to return the array using a template to achieve what you need.
 
 The following example uses a template to return the prices based on most expense:
 
@@ -26,6 +27,7 @@ The following example uses a template to return the prices based on most expense
 {{price_forecast['pricing_period']}}: {{price_forecast['price']}}
 {%- endfor -%}
 ```
+
 To get a mean value for the next 12 hours (so you can look at price change to determine increases), you can leverage a template such as this:
 
 ```python
@@ -35,6 +37,20 @@ To get a mean value for the next 12 hours (so you can look at price change to de
 
 Typically within a template you want to return a single value, to this example would need to be tailored to your specific use-case. You can experiment with Templates in the Developer Tools section of your Home Assistant portal.
 
-# Ideas 
+## Numbers don't look right?
 
-This project is early in it's creation. If you have ideas on how you want to use the Amber real-time data inside Home Assistant please let me know and I'll try my best to update to code to reflect the various use-cases. 
+Some postcodes have multiple power distributors, and the API will return the primary one. If you are on the secondary one, your numbers may be out. To do that, you can change the network name in the config
+sensor:
+
+- platform: amberelectric
+  postcode: '3000'
+  network_name: 'Jemena'
+
+```
+
+The [Australian Energy Regulator](https://www.aer.gov.au/consumers/who-is-my-distributor) has more information about finding out who your distributor is.
+
+# Ideas
+
+This project is early in it's creation. If you have ideas on how you want to use the Amber real-time data inside Home Assistant please let me know and I'll try my best to update to code to reflect the various use-cases.
+```

--- a/custom_components/amberelectric/ambermodel.py
+++ b/custom_components/amberelectric/ambermodel.py
@@ -37,8 +37,10 @@ def to_class(c: Type[T], x: Any) -> dict:
     return cast(Any, x).to_dict()
 
 
-def from_datetime(x: Any) -> datetime:
-    return dateutil.parser.parse(x)
+def from_datetime(x: Any) -> Optional[datetime]:
+    if x != None:
+        return dateutil.parser.parse(x)
+    return x
 
 
 def to_enum(c: Type[EnumT], x: Any) -> EnumT:

--- a/custom_components/amberelectric/sensor.py
+++ b/custom_components/amberelectric/sensor.py
@@ -86,8 +86,11 @@ class AmberPricingSensor(Entity):
         if self.amber_data is None:
             return 0
 
+        now = datetime.datetime.now()
+        current_period = now + (datetime.datetime.min -
+                                now) % timedelta(minutes=30)
         current_price = list(filter(
-            lambda price: price.period_type == PeriodType.ACTUAL and price.period_source == PeriodSource.THE_5_MIN, self.current_prices))
+            lambda price: price.period_type == PeriodType.ACTUAL and price.period == current_period, self.current_prices))
 
         if(self.sensor_type == CONST_GENRALUSE):
 

--- a/custom_components/amberelectric/sensor.py
+++ b/custom_components/amberelectric/sensor.py
@@ -89,7 +89,6 @@ class AmberPricingSensor(Entity):
         current_price = list(filter(
             lambda price: price.period_type == PeriodType.ACTUAL and price.period_source == PeriodSource.THE_5_MIN, self.current_prices))
 
-        _LOGGER.warn(current_price)
         if(self.sensor_type == CONST_GENRALUSE):
 
             return self.calc_amber_price(self.amber_data.data.static_prices.e1.totalfixed_kwh_price, self.amber_data.data.static_prices.e1.loss_factor, current_price[0].wholesale_kwh_price)

--- a/custom_components/amberelectric/sensor.py
+++ b/custom_components/amberelectric/sensor.py
@@ -14,7 +14,7 @@ import base64
 import logging
 
 
-SCAN_INTERVAL = timedelta(minutes=15)
+SCAN_INTERVAL = timedelta(minutes=5)
 URL = "https://api.amberelectric.com.au/prices/listprices"
 UNIT_NAME = "c/kWh"
 CONF_POSTCODE = "postcode"

--- a/custom_components/amberelectric/sensor.py
+++ b/custom_components/amberelectric/sensor.py
@@ -18,6 +18,7 @@ SCAN_INTERVAL = timedelta(minutes=15)
 URL = "https://api.amberelectric.com.au/prices/listprices"
 UNIT_NAME = "c/kWh"
 CONF_POSTCODE = "postcode"
+CONF_NETWORK_NAME = "network_name"
 
 ATTRIBUTION = "Data provided by the Amber Electric pricing API"
 ATTR_LAST_UPDATE = "last_update"
@@ -31,19 +32,26 @@ CONST_GENRALUSE = "amberGeneralUsage"
 _LOGGER = logging.getLogger(__name__)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {vol.Optional(CONF_NAME): cv.string, vol.Optional(CONF_POSTCODE): cv.string}
+    {
+        vol.Optional(CONF_NAME): cv.string,
+        vol.Required(CONF_POSTCODE): cv.string,
+        vol.Optional(CONF_NETWORK_NAME): cv.string
+    }
 )
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
 
     postcode = config.get(CONF_POSTCODE)
+    network_name = config.get(CONF_NETWORK_NAME)
     amber_data = None
     if(postcode):
         add_entities(
             [
-                AmberPricingSensor(amber_data, postcode, CONST_SOLARFIT, "Amber solar feed in tariff", "mdi:solar-power"),
-                AmberPricingSensor(amber_data, postcode, CONST_GENRALUSE, "Amber general usage price", "mdi:transmission-tower")
+                AmberPricingSensor(amber_data, postcode, network_name, CONST_SOLARFIT,
+                                   "Amber solar feed in tariff", "mdi:solar-power"),
+                AmberPricingSensor(amber_data, postcode, network_name, CONST_GENRALUSE,
+                                   "Amber general usage price", "mdi:transmission-tower")
             ]
         )
 
@@ -51,8 +59,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class AmberPricingSensor(Entity):
     """ Entity object for Amber Electric sensor."""
 
-    def __init__(self, amber_data, postcode, sensor_type, friendly_name, icon) :
+    def __init__(self, amber_data, postcode, network_name, sensor_type, friendly_name, icon):
         self.postcode = postcode
+        self.network_name = network_name
         self.amber_data = amber_data
         self.price_updated_datetime = None
         self.network_provider = None
@@ -78,71 +87,70 @@ class AmberPricingSensor(Entity):
             return 0
 
         if(self.sensor_type == CONST_GENRALUSE):
-            return self.calc_amber_price(self.amber_data.data.static_prices.e1.totalfixed_kwh_price,self.amber_data.data.static_prices.e1.loss_factor,self.current_prices[
-                            0
-                        ].wholesale_kwh_price)
+            return self.calc_amber_price(self.amber_data.data.static_prices.e1.totalfixed_kwh_price, self.amber_data.data.static_prices.e1.loss_factor, self.current_prices[
+                0
+            ].wholesale_kwh_price)
         if(self.sensor_type == CONST_SOLARFIT):
-            ## Solar FIT
-            return abs(self.calc_amber_price(self.amber_data.data.static_prices.b1.totalfixed_kwh_price,self.amber_data.data.static_prices.b1.loss_factor,self.current_prices[
-                            0
-                        ].wholesale_kwh_price))         
-        
-        return 0
+            # Solar FIT
+            return abs(self.calc_amber_price(self.amber_data.data.static_prices.b1.totalfixed_kwh_price, self.amber_data.data.static_prices.b1.loss_factor, self.current_prices[
+                0
+            ].wholesale_kwh_price))
 
+        return 0
 
     @property
     def device_state_attributes(self):
 
-       data = {} 
-       
-       data[ATTR_ATTRIBUTION] = ATTRIBUTION
-       now = datetime.datetime.now()
-       data[ATTR_SENSOR_ID] = self.sensor_type
-       data[ATTR_LAST_UPDATE]= now.strftime("%Y-%m-%d %H:%M:%S")
-       data[ATTR_GRID_NAME] =self.network_provider
-       data[ATTR_POSTCODE]= self.postcode
+        data = {}
 
+        data[ATTR_ATTRIBUTION] = ATTRIBUTION
+        now = datetime.datetime.now()
+        data[ATTR_SENSOR_ID] = self.sensor_type
+        data[ATTR_LAST_UPDATE] = now.strftime("%Y-%m-%d %H:%M:%S")
+        data[ATTR_GRID_NAME] = self.network_provider
+        data[ATTR_POSTCODE] = self.postcode
 
-       if (self.amber_data is not None):
-           future_pricing = []
-           data[ATTR_PRICE_FORCECAST] = future_pricing
-           for price_entry in self.current_prices:
-               entry = {}
-               entry["pricing_period_type"] = str(price_entry.period_type.value)
-               entry["pricing_period"] = price_entry.period.strftime("%Y-%m-%d %H:%M:%S")
-               entry["renewable_percentage"] = round(float(price_entry.renewables_percentage), 2)
-               if(self.sensor_type == CONST_GENRALUSE):
-                   entry["price"] =  self.calc_amber_price(self.amber_data.data.static_prices.e1.totalfixed_kwh_price,self.amber_data.data.static_prices.e1.loss_factor,price_entry.wholesale_kwh_price) 
-               if(self.sensor_type == CONST_SOLARFIT):
-                    entry["price"] =  abs(self.calc_amber_price(self.amber_data.data.static_prices.b1.totalfixed_kwh_price,self.amber_data.data.static_prices.b1.loss_factor,price_entry.wholesale_kwh_price)) 
-               future_pricing.append(entry)
- 
-  
-       return data
-                
-            
+        if (self.amber_data is not None):
+            future_pricing = []
+            data[ATTR_PRICE_FORCECAST] = future_pricing
+            for price_entry in self.current_prices:
+                entry = {}
+                entry["pricing_period_type"] = str(
+                    price_entry.period_type.value)
+                entry["pricing_period"] = price_entry.period.strftime(
+                    "%Y-%m-%d %H:%M:%S")
+                entry["renewable_percentage"] = round(
+                    float(price_entry.renewables_percentage), 2)
+                if(self.sensor_type == CONST_GENRALUSE):
+                    entry["price"] = self.calc_amber_price(self.amber_data.data.static_prices.e1.totalfixed_kwh_price,
+                                                           self.amber_data.data.static_prices.e1.loss_factor, price_entry.wholesale_kwh_price)
+                if(self.sensor_type == CONST_SOLARFIT):
+                    entry["price"] = abs(self.calc_amber_price(self.amber_data.data.static_prices.b1.totalfixed_kwh_price,
+                                                               self.amber_data.data.static_prices.b1.loss_factor, price_entry.wholesale_kwh_price))
+                future_pricing.append(entry)
+
+        return data
+
     def get_current_prices(self, current_values):
         future_pricing = []
         if (current_values is not None):
             last_value = None
             for value in current_values:
-               if(value.period > datetime.datetime.now()):
+                if(value.period > datetime.datetime.now()):
                     if not future_pricing:
                         future_pricing.append(last_value)
                     future_pricing.append(value)
-                
-               last_value = value    
+
+                last_value = value
         return future_pricing
 
-
-    def calc_amber_price(self,fixed_price, loss_factor, variable_price):
+    def calc_amber_price(self, fixed_price, loss_factor, variable_price):
         return round(
-                    float(fixed_price)
-                    + float(loss_factor)
-                    * float( variable_price)                
-                ,
-                2,
-            )
+            float(fixed_price)
+            + float(loss_factor)
+            * float(variable_price),
+            2,
+        )
 
     @property
     def unit_of_measurement(self):
@@ -152,15 +160,24 @@ class AmberPricingSensor(Entity):
     @Throttle(SCAN_INTERVAL)
     def update(self):
         """Get the Amber Electric data from the REST API"""
-        response = requests.post(URL, '{"postcode":"' + self.postcode + '"}')
+        params = {"postcode": self.postcode}
+        if self.network_name != None:
+            params["networkName"] = self.network_name
+
+        response = requests.post(URL, json.dumps(params))
         _LOGGER.debug(response.text)
-        self.amber_data = AmberData.from_dict(json.loads(response.text))
+        response_json = json.loads(response.text)
+        # When searching by network name, the postcode will come back empty, so fill it in from the config.
+        # This is easier than making it optional in the model
+        if response_json["data"]["postcode"] == "":
+            response_json["data"]["postcode"] = self.postcode
+
+        self.amber_data = AmberData.from_dict(response_json)
 
         if self.amber_data is not None:
             self.price_updated_datetime = self.amber_data.data.variable_prices_and_renewables[
                 0
             ].created_at
             self.network_provider = self.amber_data.data.network_provider
-            self.current_prices = self.get_current_prices(self.amber_data.data.variable_prices_and_renewables)
-
-  
+            self.current_prices = self.get_current_prices(
+                self.amber_data.data.variable_prices_and_renewables)


### PR DESCRIPTION
Postcodes don't have a 1-1 mapping with power providers, and the Amber API doesn't return all the networks that match. If your house is on the secondary network, your numbers won't match.

This patch allows you to specify the network you want to pull from the API.